### PR TITLE
Allow users to connect intents to procedures

### DIFF
--- a/backend/server/dialog.py
+++ b/backend/server/dialog.py
@@ -256,6 +256,8 @@ class DialogContext(object):
         self.classes = {}
         self.procedures = procedures
         self.execution = None
+        self.intents = {} # maps intent name to a list of required entities
+        self.intent_to_procedure = {} # maps intent name to a procedure that it is linked to
         self.reset()
 
     @property
@@ -290,6 +292,9 @@ class DialogContext(object):
 
     def add_procedure(self, procedure):
         self.procedures[procedure.name] = procedure
+
+    def add_intent(self, intent, entities):
+        self.intents[intent] = entities
 
     def get_class(self, name):
         return self.classes.get(name)

--- a/backend/server/goals/__init__.py
+++ b/backend/server/goals/__init__.py
@@ -11,3 +11,4 @@ from goals.loop import *
 from goals.edit import *
 from goals.sound import *
 from goals.execution import *
+from goals.intent import *

--- a/backend/server/goals/intent.py
+++ b/backend/server/goals/intent.py
@@ -1,0 +1,89 @@
+from goals import *
+from models import *
+
+class ConnectIntentGoal(HomeGoal):
+    """
+    Goal is to connect an intent to a procedure. 
+
+    """
+    def __init__(self, context, intent_name=None, procedure_name=None):
+        super().__init__(context)
+        self.context = context
+        self.execution = None
+        self.setattr("intent_name", intent_name)
+        self.setattr("procedure_name", procedure_name)
+
+    @property
+    def message(self):
+        if self.error:
+            return self.error
+
+        if self._message:
+            return self._message
+
+        return f"I connected the intent {self.intent_name} to the procedure {self.procedure_name}. What do you want to do now?" if self.is_complete else self.todos[-1].message
+
+    def setattr(self, attr, value):
+        if (attr == "intent_name"):
+            if not value:
+                self.todos.append(GetInputGoal(self.context, self, attr, "Which intent do you want to connect?"))
+            elif value not in self.context.intents:
+                logger.debug("context intents")
+                logger.debug(self.context.intents)
+                self.error = f"An intent with the name, {value}, has not been created."
+            else:
+                self.intent_name = value
+            return
+        elif (attr == "procedure_name"):
+            if not value:
+                self.todos.append(GetInputGoal(self.context, self, attr, "Which procedure do you want to connect?"))
+            elif value not in self.context.procedures:
+                logger.debug(value)
+                logger.debug(self.context.procedures)
+                self.error = f"The procedure with the name, {value}, has not been created."
+            else:
+                self.procedure_name = value
+        setattr(self, attr, value)
+
+    def complete(self):
+        procedure = self.context.procedures[self.procedure_name]
+        self.context.intent_to_procedure[self.intent_name] = procedure
+        return super().complete()
+
+class RunIntentGoal(HomeGoal):
+    """
+    Goal is to run the procedure connected to an intent when the intent is recognized. The goal is only complete when all slots/entities have been filled.
+    """
+    def __init__(self, context, intent_name=None):
+        super().__init__(context)
+        self.context = context
+        self.setattr("intent_name", intent_name)
+
+    @property
+    def message(self):
+        if self.error:
+            return self.error
+        elif self.todos:
+            return self.todos[-1].message
+
+    def setattr(self, attr, value):
+        if (attr == "intent_name"):
+            if value is None:
+                self.todos.append(GetInputGoal(self.context, self, attr, "What intent do you want to recognize?"))
+            elif value in self.context.intents and value not in self.context.intent_to_procedure:
+                self.error = f"The intent, {value}, has been created but hasn't been connected to a procedure, so we can't run it. You can connect it by saying, \"connect the intent {value} to the procedure [procedure name].\""
+            else:
+                self.procedure = self.context.intent_to_procedure[value]
+            return
+        setattr(self, attr, value)
+
+    def complete(self):
+        """
+        Complete the goal
+
+        Completion of goal involves:
+        1. Transition from "home" state to "executing" state
+        2. Execute the procedure
+        """
+        execute = ExecuteGoal(self.context, self.procedure.name)
+        return execute.complete()

--- a/backend/server/models/__init__.py
+++ b/backend/server/models/__init__.py
@@ -4,3 +4,4 @@ from models.condition import *
 from models.klass import *
 from models.valueof import *
 from models.execution import *
+from models.intent import *

--- a/backend/server/models/intent.py
+++ b/backend/server/models/intent.py
@@ -1,0 +1,24 @@
+from helpers import to_snake_case
+tab = "    "
+
+class Intent(object):
+    """Represents an intent"""
+    def __init__(self, name, entities=None):
+        self.name = name
+        # List of all entities required for this intent.
+        self.entities = entities if entities else []
+
+    def __str__(self):
+        return f"Intent {self.name}: {self.entities}"
+
+    def json(self):
+        return {
+            "name": self.name,
+            "entities": [a.json() for a in self.entities]
+        }
+
+    def __eq__(self, other):
+        if not isinstance(other, type(self)):
+            return NotImplemented
+
+        return self.name == self.name and self.entities == self.entities

--- a/backend/server/nlu.py
+++ b/backend/server/nlu.py
@@ -37,6 +37,9 @@ until_stop_condition_regex = "i say stop"
 variable_regex = "(?:(?:a|the) variable)(?: (.+))?|variable (.+)"
 procedure_regex = "(?:(?:a|the) procedure|procedure)(?: called)?(?: (.+))?"
 
+intent_to_procedure_regex1 = "connect (?:(?:a|the|an) intent)(?: (.+)) (?:to|with) (?:(?:a|the) procedure)(?: (.+))"
+intent_to_procedure_regex2 = "connect (?:(?:a|the) procedure)(?: (.+)) (?:to|with) (?:(?:a|the|an) intent)(?: (.+))"
+
 action_regexes = [
     say_regex, play_sound_regex,
     set_variable_regex, create_variable_regex, add_to_variable_regex, subtract_from_variable_regex,
@@ -82,6 +85,12 @@ class SemanticNLU(object):
         elif re.search(delete_procedure_regex, message):
             match = re.search(delete_procedure_regex, message)
             return DeleteProcedureGoal(self.context, procedure_name=self.parse_procedure(group(match, 1)))
+        elif re.search(intent_to_procedure_regex1, message):
+            match = re.search(intent_to_procedure_regex1, message)
+            return ConnectIntentGoal(self.context, intent_name=self.parse_procedure(group(match, 1)), procedure_name=group(match, 2))
+        elif re.search(intent_to_procedure_regex2, message):
+            match = re.search(intent_to_procedure_regex2, message)
+            return ConnectIntentGoal(self.context, intent_name=self.parse_procedure(group(match, 2)), procedure_name=group(match, 1))
 
     def parse_step_goal(self, message):
         """Parse function for goals and intents that relate to editing"""

--- a/backend/server/rasa_nlu.py
+++ b/backend/server/rasa_nlu.py
@@ -19,7 +19,8 @@ intent_goal = {
     "go_to_step": GoToStepGoal,
     "delete_step": DeleteStepGoal,
     "add_step": AddStepGoal,
-    "change_step": ChangeStepGoal
+    "change_step": ChangeStepGoal,
+    "run_intent": RunIntentGoal
 }
 
 intent_entities = {
@@ -28,7 +29,8 @@ intent_entities = {
     "delete_procedure": ["procedure_name"],
     "run_procedure": ["procedure_name"],
     "edit_procedure": ["procedure_name"],
-    "say": ["say_phrase"]
+    "say": ["say_phrase"],
+    "run_intent": ["intent_name", "entities"]
 }
 
 class RasaNLU(object):
@@ -67,10 +69,9 @@ class RasaNLU(object):
             # If confidence is less than threshold, do not use intent
             logger.debug("confidence is less than threshold")
             return None
-        if intent["name"] not in intent_goal:
-            # If intent is not supported currently by the NLU
-            logger.debug("intent not supported by NLU")
-            return None
+        original_intent = intent["name"].replace("_", " ")
+        if original_intent in self.context.intents:
+            return RunIntentGoal(self.context, original_intent)
 
         goal = intent_goal[intent["name"]]
         entities = {}

--- a/frontend/public/css/experiment.css
+++ b/frontend/public/css/experiment.css
@@ -146,7 +146,6 @@
 }
 
 #nlu {
-    /* display: flex; */
     padding: 2rem;
     flex-direction: column;
 }

--- a/frontend/public/js/experiment.js
+++ b/frontend/public/js/experiment.js
@@ -112,7 +112,13 @@ const example_commands = {
             "examples": [
                 "delete hello"
             ]
-        }
+        },
+        {
+            "title": "Connect an Intent to a Procedure or Program",
+            "examples": [
+                "connect the intent greet to the procedure greet me back"
+            ]
+        },
     ],
     "creating": [{
         "title": "Finish Creating",
@@ -247,38 +253,6 @@ let submitText = () => {
     textbox.value = "";
 }
 
-let trainNLU = () => {
-    let intentElements = document.getElementsByClassName("intent");
-    let trainingElements = document.getElementsByClassName("training");
-    let intents = [];
-    let trainingData = [];
-    for (var i=0; i < intentElements.length; i++) {
-        let intent = intentElements[i].value;
-        if (intent != "") {
-            intents.push(intent);
-            trainingData.push(trainingElements[i].value);
-        }
-    }
-    if (intents != []) {
-        socketApi.emit('train', {
-            intents: intents,
-            trainingData: trainingData,
-        })
-    }
-}
-
-let addIntent = () => {
-    let nluContainer = document.getElementById('nlu');
-    let newIntent = document.createElement('div');
-    newIntent.innerHTML = `<div><b>INTENT</b>: What do you want Convo to understand?</div>
-    <input class="intent" type="text" id="intent" placeholder="keep a recipe book"/>`;
-    let newTrainingData = document.createElement('div');
-    newTrainingData.innerHTML = `<div><b>TRAINING DATA</b>: How might you say this?</div>
-    <input class="training" type="text" id="training_data" placeholder="I want to save a recipe"/>`;
-    nluContainer.append(newIntent);
-    nluContainer.append(newTrainingData);
-}
-
 let submitMessage = (message, speak) => {
     addUtter("user-utter", message);
     handleSubmit(message, speak);
@@ -324,6 +298,40 @@ let addUtter = (className, message, speak = true) => {
         conversation.scrollTop = conversation.scrollHeight;
     }
 };
+
+let trainNLU = () => {
+    synth.cancel();
+    let intentElements = document.getElementsByClassName("intent");
+    let trainingElements = document.getElementsByClassName("training");
+    let intents = [];
+    let trainingData = [];
+    for (var i=0; i < intentElements.length; i++) {
+        let intent = intentElements[i].value;
+        if (intent != "") {
+            intents.push(intent);
+            trainingData.push(trainingElements[i].value);
+        }
+    }
+    if (intents != []) {
+        socketApi.emit('train', {
+            sid: localStorage.getItem('sid'),
+            intents: intents,
+            trainingData: trainingData,
+        })
+    }
+}
+
+let addIntent = () => {
+    let nluContainer = document.getElementById('nlu');
+    let newIntent = document.createElement('div');
+    newIntent.innerHTML = `<div><b>INTENT</b>: What do you want Convo to understand?</div>
+    <input class="intent" type="text" id="intent" placeholder="keep a recipe book"/>`;
+    let newTrainingData = document.createElement('div');
+    newTrainingData.innerHTML = `<div><b>TRAINING DATA</b>: How might you say this?</div>
+    <input class="training" type="text" id="training_data" placeholder="I want to save a recipe"/>`;
+    nluContainer.append(newIntent);
+    nluContainer.append(newTrainingData);
+}
 
 let addExamplePrograms = () => {
     document.getElementById('example-programs').innerHTML = `


### PR DESCRIPTION
Allow users to connect intents to procedures by saying specific phrases like "connect the intent [greet] to the procedure [greet me back]." This will provide error messages when the intent provided has not yet been trained, or the procedure name provided has not yet been created. Allows overwriting of intent to procedure connections (i.e. connecting intent A to procedure B and then connecting intent A to procedure C overwrites the first connection, so only procedure C executes when intent A is recognized). Make sure that the unconstrained NL toggle is on to recognize intents!

Entity/slot filling is currently still unsupported.