### PR TITLE
Incorporate slot filling before an intent will run a procedure

### DIFF
--- a/backend/server/dialog.py
+++ b/backend/server/dialog.py
@@ -258,6 +258,7 @@ class DialogContext(object):
         self.execution = None
         self.intents = {} # maps intent name to a list of required entities
         self.intent_to_procedure = {} # maps intent name to a procedure that it is linked to
+        self.entities = {} # maps entities to their respective values, if given
         self.reset()
 
     @property
@@ -295,6 +296,11 @@ class DialogContext(object):
 
     def add_intent(self, intent, entities):
         self.intents[intent] = entities
+        for entity in entities:
+            self.entities[entity] = None
+
+    def add_entity(self, entity, value):
+        self.entities[entity] = value
 
     def get_class(self, name):
         return self.classes.get(name)

--- a/backend/server/goals/input.py
+++ b/backend/server/goals/input.py
@@ -63,6 +63,37 @@ class GetUserInputGoal(BaseGoal):
         variables[self.variable] = variables[self.value.variable] if isinstance(self.value, ValueOf) else self.value
         return super().complete()
 
+class GetEntityInputGoal(HomeGoal):
+    """Goal for getting user entity input during recognition of an intent"""
+    def __init__(self, context, entity, message):
+        super().__init__(context)
+        self.entity = entity
+        self._message = message
+        self.value = None
+
+    @property
+    def is_complete(self):
+        return self.value is not None
+
+    @property
+    def message(self):
+        return "GetEntityInputGoal completed!" if self.is_complete else self._message
+
+    def advance(self):
+        logger.debug(f"Advancing {self.__class__.__name__}...")
+
+        if self.context.parsed and isinstance(self.context.parsed, ValueOf):
+            self.value = self.context.parsed
+        else:
+            message = self.context.current_message
+            number = parse_number(message)
+            self.value = number if number is not None else message
+
+    def complete(self):
+        logger.debug(self.context.entities)
+        self.context.entities[self.entity] = self.context.execution.variables[self.value.variable] if isinstance(self.value, ValueOf) else self.value
+        return super().complete()
+
 class GetUserInputActionGoal(ActionGoal):
     """Goal for adding action to get user input"""
     def __init__(self, context, variable, prompt=None):

--- a/backend/server/goals/intent.py
+++ b/backend/server/goals/intent.py
@@ -73,6 +73,12 @@ class RunIntentGoal(HomeGoal):
             elif value in self.context.intents and value not in self.context.intent_to_procedure:
                 self.error = f"The intent, {value}, has been created but hasn't been connected to a procedure, so we can't run it. You can connect it by saying, \"connect the intent {value} to the procedure [procedure name].\""
             else:
+                required_entities = self.context.intents[value]
+                for entity in required_entities:
+                    if entity not in self.context.entities:
+                        self.error = f"The entity, {entity}, has not yet been initialized."
+                    elif self.context.entities[entity] == None:
+                        self.todos.append(GetEntityInputGoal(self.context, entity, f"What is the {entity}?"))
                 self.procedure = self.context.intent_to_procedure[value]
             return
         setattr(self, attr, value)

--- a/backend/server/manage.py
+++ b/backend/server/manage.py
@@ -138,7 +138,7 @@ def train(data):
     sio.emit("trained")
 
 def add_intents_and_entities(context, intents, trainingData):
-    logger.debug("starting to add intents and entities")
+    context.add_intent("greet", [])
     for i in range(len(intents)):
         intent = intents[i]
         intent = intent.replace(" ", "_")

--- a/backend/server/rasa_nlu.py
+++ b/backend/server/rasa_nlu.py
@@ -71,11 +71,13 @@ class RasaNLU(object):
             return None
         original_intent = intent["name"].replace("_", " ")
         if original_intent in self.context.intents:
+            for e in intents["entities"]:
+                self.context.add_entity(e["entity"], e["value"])
             return RunIntentGoal(self.context, original_intent)
+        else:
+            goal = intent_goal[intent["name"]]
+            entities = {}
+            if intents["entities"]:
+                entities.update({e["entity"]: e["value"] for e in intents["entities"] if e["entity"] in intent_entities[intent["name"]]})
 
-        goal = intent_goal[intent["name"]]
-        entities = {}
-        if intents["entities"]:
-            entities.update({e["entity"]: e["value"] for e in intents["entities"] if e["entity"] in intent_entities[intent["name"]]})
-
-        return goal(self.context, **entities)
+            return goal(self.context, **entities)


### PR DESCRIPTION
When a user trains Convo on an intent that uses entities, Convo will keep track of which entities/slots are required for that intent. Convo will prompt a user for missing entities when the user tries to invoke a procedure by saying something that has the corresponding intent. 

Examples: 
Intent: make robot dance
Training Data: make my robot dance, make the robot spin around, turn the robot around, turn the robot 180 degrees
Intent: say the weather
Training Data: get the weather for \[Boston\](city), say the weather in \[Vancouver\](city), get the temperature, what's the weather?, what's the weather in \[Madrid\](city)?
Intent: bake instruction
Training Data: i want to bake the cookies for \[30 minutes\](bake_time) at \[350 degrees\](bake temp), put in oven at \[400 degrees\](bake temp), bake for \[10 minutes\](bake_time), heat in oven for \[half an hour\](bake_time) at \[400\](bake temp)

Sample test:
After connecting bake instruction to procedure A and then saying "bake for 30 minutes," Convo will ask "What is the bake temp?" and then once the user responds "400 degrees" (or anything else), Convo will run procedure A. 