### PR TITLE
connect entities to variables in procedures

### DIFF
--- a/backend/server/dialog.py
+++ b/backend/server/dialog.py
@@ -11,7 +11,8 @@ state_machine = {
     "home": {
         "create_procedure": "creating",
         "execute": "executing",
-        "edit": "editing"
+        "edit": "editing",
+        "connect_intent": "editing"
     },
     "creating": {
         "complete": "home"
@@ -248,7 +249,7 @@ class DialogContext(object):
     """
     Contains context and information needed to process messages and maintain conversations
 
-    More specifically, contains the classes, procedures, state, conversation, goals
+    More specifically, contains the classes, procedures, intents (and entities), state, conversation, goals
     and execution/editing subcontexts for the client
     """
     def __init__(self, sid, procedures={}):

--- a/backend/server/goals/input.py
+++ b/backend/server/goals/input.py
@@ -65,11 +65,13 @@ class GetUserInputGoal(BaseGoal):
 
 class GetEntityInputGoal(HomeGoal):
     """Goal for getting user entity input during recognition of an intent"""
-    def __init__(self, context, entity, message):
+    def __init__(self, context, intent, entity, message):
         super().__init__(context)
+        self.intent = intent
         self.entity = entity
         self._message = message
         self.value = None
+        self.procedure = self.context.intent_to_procedure[self.intent]
 
     @property
     def is_complete(self):
@@ -92,6 +94,12 @@ class GetEntityInputGoal(HomeGoal):
     def complete(self):
         logger.debug(self.context.entities)
         self.context.entities[self.entity] = self.context.execution.variables[self.value.variable] if isinstance(self.value, ValueOf) else self.value
+        for i in range(len(self.procedure.actions)):
+            action = self.procedure.actions[i]
+            if type(action) is CreateVariableAction:
+                if action.variable == self.entity:
+                    # replace this action
+                    self.procedure.actions[i] = CreateVariableAction(self.entity, self.context.entities[self.entity])
         return super().complete()
 
 class GetUserInputActionGoal(ActionGoal):

--- a/backend/server/goals/variable.py
+++ b/backend/server/goals/variable.py
@@ -3,14 +3,18 @@ from goals import *
 
 class CreateVariableActionGoal(ActionGoal):
     """Goal for adding a create variable action"""
-    def __init__(self, context, name=None, value=None):
+    def __init__(self, context, name=None, value=None, prepend=False):
         super().__init__(context)
         self.setattr("value", value)
         self.setattr("name", name)
+        self.prepend = prepend
 
     def complete(self):
         assert hasattr(self, "actions")
-        self.actions.append(CreateVariableAction(self.name, self.value))
+        if self.prepend:
+            self.actions.insert(0, CreateVariableAction(self.name, self.value))
+        else:
+            self.actions.append(CreateVariableAction(self.name, self.value))
         self.variables.add(self.name)
         return super().complete()
 

--- a/backend/server/rasa_nlu.py
+++ b/backend/server/rasa_nlu.py
@@ -40,7 +40,7 @@ class RasaNLU(object):
     Uses the main function parse_message to connect to Rasa NLU and retrieve intent and entity
     """
 
-    def __init__(self, context, confidence_threshold=0.3):
+    def __init__(self, context, confidence_threshold=0.7):
         self.context = context
 
         # Threshold for the confidence returned by the Rasa NLU for the top intent


### PR DESCRIPTION
When a user connects an intent to a procedure, any entities corresponding to that intent are created as variables (set to a default value of 0) in the procedure. This action is added onto the end of the list of actions associated with the procedure. The user can then proceed to edit the procedure and use the variables/entities associated with that intent. When running a procedure via recognizing an intent, we take any values the user gives as entities and replace the original `CreateVariableAction` with a new `CreateVariableAction` that is set to the new value given by the user.

