### PR TITLE
add highlighting and train functionality

### DIFF
--- a/frontend/react/src/App.jsx
+++ b/frontend/react/src/App.jsx
@@ -91,8 +91,8 @@ class App extends Component {
             <Switch>
               <Route exact path="/" component={Info} />
               <Route path="/create-intents" render={() => <CreateIntentPage sid={this.state.sid} socketFlask={this.state.socketFlask} />} />
-              <Route path="/program" render={() => <ProgramPage sid={this.state.sid} socketFlask={this.state.socketFlask} />} />
-              <Route path="/talk-to-convo" render={() => <TalkToConvoPage sid={this.state.sid} socketFlask={this.state.socketFlask} />} />
+              <Route path="/program" render={() => <ProgramPage sid={this.state.sid} socketNode={this.state.socketNode} socketFlask={this.state.socketFlask} />} />
+              <Route path="/talk-to-convo" render={() => <TalkToConvoPage sid={this.state.sid} socketNode={this.state.socketNode} socketFlask={this.state.socketFlask} />} />
               <Route component={NoMatch} />
             </Switch>
           </Layout>

--- a/frontend/react/src/ProgramPage.jsx
+++ b/frontend/react/src/ProgramPage.jsx
@@ -402,7 +402,7 @@ const ProgramPage = (props) => {
                 <div className="example-action" style={{ marginBottom: '10px' }}>
                     <div className="action-title"><b>{action.title}</b></div>
                     {action.examples.map(ex => {
-                        return (<div class="action-example"><em>{ex}</em></div>)
+                        return (<div><em>{ex}</em></div>)
                     })}
                 </div>
             )
@@ -423,7 +423,7 @@ const ProgramPage = (props) => {
         <Styles>
             <div className="experiment-container">
                 {renderSidebar()}
-                <ChatBox sid={props.sid} isUnconstrained={true} state={state} parentCallback={callbackFunction} socketNode={props.socketNode} socketFlask={props.socketFlask}/>
+                <ChatBox sid={props.sid} isUnconstrained={false} pageId={"program"} state={state} parentCallback={callbackFunction} socketNode={props.socketNode} socketFlask={props.socketFlask}/>
             </div>
         </Styles>
     )

--- a/frontend/react/src/TalkToConvoPage.jsx
+++ b/frontend/react/src/TalkToConvoPage.jsx
@@ -143,7 +143,7 @@ const TalkToConvoPage = (props) => {
     return (
         <Styles>
             <div className="experiment-container">
-                <ChatBox sid={props.sid} isUnconstrained={true} state={state} parentCallback={callbackFunction} socketNode={props.socketNode} socketFlask={props.socketFlask}/>
+                <ChatBox sid={props.sid} isUnconstrained={true} state={state} pageId={"talk"} parentCallback={callbackFunction} socketNode={props.socketNode} socketFlask={props.socketFlask}/>
             </div>
         </Styles>
     )

--- a/frontend/react/src/components/ChatBox.jsx
+++ b/frontend/react/src/components/ChatBox.jsx
@@ -7,7 +7,8 @@ synth.cancel();
 const ChatBox = (props) => {
     const [isRecording, setIsRecording] = useState(false);
     const [userMessage, setUserMessage] = useState("");
-    const [chatMessages, setChatMessages] = useState([]); // list of chat messages with the label of either convo or the user
+    // list of chat messages with the label of either convo or the user, have messages persist
+    const [chatMessages, setChatMessages] = useState(localStorage.getItem(props.pageId) ? JSON.parse(localStorage.getItem(props.pageId)) : []);
 
     let context = useRef(null);
     let processor = useRef(null);
@@ -179,6 +180,10 @@ const ChatBox = (props) => {
             document.removeEventListener("keyup", handleKeyUp)
         }
     }, [isRecording, props.socketNode, startRecording, stopRecording]);
+
+    useEffect(() => {
+        localStorage.setItem(props.pageId, JSON.stringify(chatMessages));
+    }, [chatMessages, props.pageId]);
 
     useEffect(() => {
         document.querySelector('.conversation').scrollTop = document.querySelector('.conversation').scrollHeight;


### PR DESCRIPTION
Allows user to highlight words or phrases as part of entities. Highlights are color coded based on the entity. When the user is done highlighting, proper syntax for what the training data should look like appears. Edge cases tested: can't highlight outside of your existing phrase, can't highlight nothing, can't highlight over other highlights of either the same or different color

Note that there are still a couple things to work on, most notably an 'undo' function. Also, would be nice to have formatted text also revert back to the 'highlighted' model.

When training intents, a spinner appears while Rasa trains in the background. The word 'Done!' will appear when training has finished.