### PR TITLE
allow intent fields to persist

### DIFF
--- a/frontend/react/src/CreateIntentPage.jsx
+++ b/frontend/react/src/CreateIntentPage.jsx
@@ -45,7 +45,8 @@ const Styles = styled.div`
 `;
 
 const CreateIntentPage = props => {
-    const [intents, setIntents] = useState(['']);
+    const [intentId, setIntentId] = useState(localStorage.getItem("intentIndex") ? JSON.parse(localStorage.getItem("intentIndex")) : 1); // keep a unique id for each intent card
+    const [intents, setIntents] = useState(localStorage.getItem("intents") ? JSON.parse(localStorage.getItem("intents")) : ["intent0"]);
     const [isTraining, setIsTraining] = useState(false);
     const [finishedTraining, setFinishedTraining] = useState(false); // stays true if finished training even once
 
@@ -57,8 +58,16 @@ const CreateIntentPage = props => {
         }, [props.socketFlask]
     );
 
+    useEffect(() => {
+        localStorage.setItem("intentIndex", JSON.stringify(intentId));
+        localStorage.setItem("intents", JSON.stringify(intents));
+    }, [intentId, intents]);
+
     const handleAddMoreIntents = () => {
-        let oneMoreIntent = intents.concat([''])
+        var oneMoreIntentId = intentId + 1;
+        var newIntentId = 'intent' + oneMoreIntentId.toString();
+        setIntentId(oneMoreIntentId);
+        let oneMoreIntent = intents.concat([newIntentId])
         setIntents(oneMoreIntent);
     };
 
@@ -126,7 +135,7 @@ const CreateIntentPage = props => {
     return (     
         <Styles>
             <div className="intent-page">
-                {intents.map(() => (<IntentCard />))}
+                {intents.map((intentId) => (<IntentCard intentId={intentId} />))}
                 {renderIntentCardAddMoreButton()}
             </div>
             {renderTrainButton()}

--- a/frontend/react/src/components/IntentCard.jsx
+++ b/frontend/react/src/components/IntentCard.jsx
@@ -198,14 +198,26 @@ class IntentCard extends Component {
         super(props);
 
         this.state = {
-            intent: '',
-            phrases: [''],
-            entities: [''],
+            intent: localStorage.getItem(this.props.intentId) ? JSON.parse(localStorage.getItem(this.props.intentId)) : '',
+            phrases: localStorage.getItem(this.props.intentId + "phrases") ? JSON.parse(localStorage.getItem(this.props.intentId + "phrases")) : [''],
+            entities: localStorage.getItem(this.props.intentId + "entities") ? JSON.parse(localStorage.getItem(this.props.intentId + "entities")) : [''],
             showEntities: false,
             highlightColor: '',
             highlightColorClass: 'label-input',
             isHighlighting: false
         };
+    }
+
+    componentDidUpdate(prevProps, prevState) {
+        if (prevState.intent !== this.state.intent) {
+            localStorage.setItem(this.props.intentId, JSON.stringify(this.state.intent));
+        }
+        if (prevState.phrases !== this.state.phrases) {
+            localStorage.setItem(this.props.intentId + "phrases", JSON.stringify(this.state.phrases));
+        }
+        if (prevState.entities !== this.state.entities) {
+            localStorage.setItem(this.props.intentId + "entities", JSON.stringify(this.state.entities));
+        }
     }
 
     toggleShowEntities = () => {


### PR DESCRIPTION
Store the intent names, phrases, and entities in `localStorage` whenever they are updated so that the user can leave the page and come back to them still there.